### PR TITLE
Updated eslint to next major version to fix TypeError

### DIFF
--- a/examples/dev-stack/package.json
+++ b/examples/dev-stack/package.json
@@ -11,7 +11,7 @@
     "autoprefixer-loader": "^2.0.0",
     "babel": "^5.0.8",
     "babel-core": "^5.6.5",
-    "babel-eslint": "^3.0.1",
+    "babel-eslint": "^4.0.1",
     "babel-loader": "^5.0.0",
     "compression": "^1.4.0",
     "css-loader": "^0.15.1",


### PR DESCRIPTION
Fixes this error: TypeError: Cannot read property 'visitClass' of undefined
Update to next major version is sufficient solution.
